### PR TITLE
Update config to fix issue where document edits were not saved

### DIFF
--- a/client_config/templates/nuxeo.conf.j2
+++ b/client_config/templates/nuxeo.conf.j2
@@ -5,9 +5,10 @@
 ##-----------------------------------------------------------------------------
 ## General parameters
 ##-----------------------------------------------------------------------------
-nuxeo.templates=postgresql,drive,s3binaries
+nuxeo.templates=postgresql,drive,s3binaries,jsf
 nuxeo.url={{ nuxeo_url }}
 nuxeo.preview.legacy.enabled=true
+nuxeo.server.http.maxPartCount=-1
 
 ##-----------------------------------------------------------------------------
 ## database


### PR DESCRIPTION
Config changes:
- Set no limit on number of parts submitted in multi-part upload
- Add jsf to nuxeo.templates config parameter

### Nuxeo tech support explanation of the solution:

As of 2023.33, configuration parameters were introduced that set a limit on the number of parts that can be submitted in a multi-part server request - defaulting to the following values:


    nuxeo.server.http.maxPartCount=50
    nuxeo.server.http.maxPartHeaderSize=512


JSF UI must account for one part per widget when making an update, so a form with a large number of widgets (such as ucldc_fullMetadata with over 50) would result in updates failing silently. The OOTB jsf template accounts for this by setting nuxeo.server.http.maxPartCount=-1 to indicate no limit, however I notice the jsf template is missing from your configuration. So from here, I would suggest testing one of the following changes to your nuxeo.conf file:

    Set nuxeo.server.http.maxPartCount=-1
    Append jsf to the list of templates included in the nuxeo.templates configuration parameter


