### PR TITLE
Decrease s3 file cache size from 850 to 300GB

### DIFF
--- a/client_config/templates/nuxeo.conf.j2
+++ b/client_config/templates/nuxeo.conf.j2
@@ -51,7 +51,7 @@ elasticsearch.override.pageproviders=default_search,default_document_suggestion,
 ##-----------------------------------------------------------------------------
 nuxeo.s3storage.bucket={{ nuxeo_s3storage_bucket }}
 nuxeo.s3storage.region={{ nuxeo_s3storage_region }}
-nuxeo.s3storage.cachesize=850GB
+nuxeo.s3storage.cachesize=300GB
 # the following is optional
 #nuxeo.s3storage.bucket_prefix=yourfolder/
 


### PR DESCRIPTION
The largest nuxeo binary we have right now is 210.6GB. Decreasing the local cache size for files fetched from S3 to 300GB.